### PR TITLE
RPC methods aliases

### DIFF
--- a/core/src/calls.rs
+++ b/core/src/calls.rs
@@ -40,7 +40,9 @@ pub enum RemoteProcedure<T: Metadata> {
 	/// A method call
 	Method(Box<RpcMethod<T>>),
 	/// A notification
-	Notification(Box<RpcNotification<T>>)
+	Notification(Box<RpcNotification<T>>),
+	/// An alias to other method,
+	Alias(String),
 }
 
 impl<F: Send + Sync + 'static> RpcMethodSync for F where

--- a/macros/examples/meta-macros.rs
+++ b/macros/examples/meta-macros.rs
@@ -22,7 +22,7 @@ build_rpc_trait! {
 		fn call(&self, u64) -> BoxFuture<String, Error>;
 
 		/// Performs asynchronous operation with meta
-		#[rpc(meta, name = "callAsyncMeta")]
+		#[rpc(meta, name = "callAsyncMeta", alias = [ "callAsyncMetaAlias", ])]
 		fn call_meta(&self, Self::Metadata, u64) -> BoxFuture<String, Error>;
 	}
 }

--- a/macros/src/auto_args.rs
+++ b/macros/src/auto_args.rs
@@ -109,30 +109,45 @@ macro_rules! build_rpc_trait {
 	};
 
 	( WRAP $del: expr =>
-		(name = $name: expr)
+		(name = $name: expr $(, alias = [ $( $alias: expr, )+ ])*)
 		fn $method: ident (&self $(, $param: ty)*) -> $result: tt <$out: ty, Error>
 	) => {
 		$del.add_method($name, move |base, params| {
 			$crate::Wrap::wrap_rpc(&(Self::$method as fn(&_ $(, $param)*) -> $result <$out, Error>), base, params)
-		})
+		});
+		$(
+			$(
+				$del.add_alias($name, $alias);
+			)+
+		)*
 	};
 
 	( WRAP $del: expr =>
-		(async, name = $name: expr)
+		(async, name = $name: expr $(, alias = [ $( $alias: expr, )+ ])*)
 		fn $method: ident (&self $(, $param: ty)*) -> $result: tt <$out: ty, Error>
 	) => {
 		$del.add_async_method($name, move |base, params| {
 			$crate::WrapAsync::wrap_rpc(&(Self::$method as fn(&_ $(, $param)*) -> $result <$out, Error>), base, params)
-		})
+		});
+		$(
+			$(
+				$del.add_alias($name, $alias);
+			)+
+		)*
 	};
 
 	( WRAP $del: expr =>
-		(meta, name = $name: expr)
+		(meta, name = $name: expr $(, alias = [ $( $alias: expr, )+ ])*)
 		fn $method: ident (&self, Self::Metadata $(, $param: ty)*) -> $result: tt <$out: ty, Error>
 	) => {
 		$del.add_method_with_meta($name, move |base, params, meta| {
 			$crate::WrapMeta::wrap_rpc(&(Self::$method as fn(&_, Self::Metadata $(, $param)*) -> $result <$out, Error>), base, params, meta)
-		})
+		});
+		$(
+			$(
+				$del.add_alias($name, $alias);
+			)+
+		)*
 	};
 }
 

--- a/macros/src/delegates.rs
+++ b/macros/src/delegates.rs
@@ -110,6 +110,10 @@ impl<T, M> IoDelegate<T, M> where
 		}
 	}
 
+	pub fn add_alias(&mut self, from: &str, to: &str) {
+		self.methods.insert(from.into(), RemoteProcedure::Alias(to.into()));
+	}
+
 	pub fn add_method<F>(&mut self, name: &str, method: F) where
 		F: Fn(&T, Params) -> Data,
 		F: Send + Sync + 'static,


### PR DESCRIPTION
Closes #44 

I've decided to add simple aliases to `core` as well.